### PR TITLE
resolve github-readme-stats "Maximum retries"

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,4 +28,4 @@
 
 #### Development Stuffs:
 
-<p>&nbsp;<img align="center" src="https://github-readme-stats.vercel.app/api?username=jeffchiucp&show_icons=true&locale=en" alt="jeffchiucp" /></p>
+<p>&nbsp;<img align="center" src="https://github-readme-stats.zohan.tech/api?username=jeffchiucp&show_icons=true&locale=en" alt="jeffchiucp" /></p>


### PR DESCRIPTION
Observed that demo service "https://github-readme-stats.vercel.app/" is hitting the API Limit. Causing the stats not displaying.

Fix is to Change https://github-readme-stats.vercel.app to another URL provided


